### PR TITLE
Full Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**/node_modules/
+**/.git
+**/README.md
+**/LICENSE
+**/.vscode
+**/npm-debug.log
+**/coverage
+**/.env
+**/.editorconfig
+**/.aws
+**/dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,36 @@
-**/node_modules/
+.DS_Store
+node_modules
+/dist
+
 **/.git
 **/README.md
 **/LICENSE
-**/.vscode
-**/npm-debug.log
-**/coverage
-**/.env
+
 **/.editorconfig
 **/.aws
-**/dist
+
+/tests/e2e/reports/
+selenium-debug.log
+
+/tests/e2e/reports/
+selenium-debug.log
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+home.deploy.md
+home.config.yml

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,0 +1,57 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+  workflow_dispatch:
+  release:
+    types: [published, edited]
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/foxusa/storedown
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 node_modules
 /dist
 
-/tests/e2e/reports/
-selenium-debug.log
-
 # local env files
 .env.local
 .env.*.local
@@ -13,6 +10,8 @@ selenium-debug.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+/tests/e2e/reports/
+selenium-debug.log*
 
 # Editor directories and files
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Build
+FROM node:16-alpine3.15 as builder
+
+WORKDIR /app
+
+# Build tools
+RUN apk add --no-cache \
+    build-base \
+    gcc \
+    g++ \
+    make
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Build dist
+COPY . .
+RUN npm run build
+
+# Relese
+FROM nginx:stable-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html/
+
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
 
 # Install dependencies
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 # Build dist
 COPY . .

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ Click `RUN IN LOCAL MODE` in the bottom left to quickly demo/test.
 - Data Import(JSON, and YML)
 - TODO markdown
 
+## How to run
 
+### Docker
+
+```bash
+docker run -d --restart=unless-stopped -p 80:80 foxusa/storedown:latest
+```
 
 ## Quick Links
 - [How to install](./docs/install.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+# You can change your port or volume location
+services:
+  storedown:
+    image: foxusa/storedown:latest
+    container_name: storedown
+    ports:
+      - 80:80
+    restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,8 @@
+server { 
+    listen 80;
+    server_name storedown;
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
The purpose of this draft PR is to track adding support for Docker as requested by various users on Reddit.

- [x] Add Docker Ignore
- [x] Add Dockerfile with Multi-Stage support
- [x] Update README with instructions on how to use Docker Image
- [x] Provide example `docker-compose.yml` for running StoreDown
- [x] Add support for building, tagging, and releasing `StoreDown` images to `ghcr.io` and possibly `DockerHub`

@FoxUSA Do you currently have an account for StoreDown in `hub.docker.com` ? If not, can you create one under `storedown` username. That way the image can be created as  `storedown/storedown:latest`