### PR TITLE
Added special UUID string field that resolves #11

### DIFF
--- a/src/views/Entry.vue
+++ b/src/views/Entry.vue
@@ -35,6 +35,9 @@
                 <v-layout wrap>
                   <v-flex :class="field.size ? `xs${field.size}` : 'xs12 sm6 xl4'" v-for="field in group.fields" :key="field.name">
 
+                    <!-- Special ID field to give a different disabled property and maybe show shortened form  -->
+                    <v-text-field :color="field.color ? field.color :'white'" v-if="field.type=='uuid_string'" v-model="item[field.name]" :label="field.displayName" :disabled="mostlyDisabled"></v-text-field>
+
                     <!-- String  -->
                     <v-text-field :color="field.color ? field.color :'white'" v-if="field.type=='string'" v-model="item[field.name]" :label="field.displayName" :disabled="field.disabled"></v-text-field>
 
@@ -144,6 +147,12 @@ export default {
         return
       }
       return this.config.dataDefinition
+    },
+    mostlyDisabled: function () {
+      if (!this.$route.params.id) {
+        return false
+      }
+      return true
     }
   },
   mounted () {


### PR DESCRIPTION
Using the special `uuid_string` type makes it refer to the mostlyDisabled computed property and only allows editing if there's no ID in the route. (I tried making it configurable by doing `!this.$route.params.id && !this.config.dataDefinition.fields._id.disabled` but accessing that field that way doesn't make vue happy and I don't yet know enough to know why.) The default schema is untouched, so this shouldn't affect anyone else for now.

This also sets the stage for special handling of the field for barcode integration features, from scanning intents to transforming input (for example, because of how QR codes encode values, a digit-only UUID representation is much more compact than its string equivalent, and making a proof of concept of this that works with any random keyboard scanner will be my next target.) Rebased onto PR #12 and everything tests out fine, should merge without conflicts. I readily admit I have very little idea what I'm doing, so unload all barrels and I'll do as directed to improve.

Potentially resolves #11.