### PR TITLE
Updated yaml.safeDump and List.vue sortable table

### DIFF
--- a/src/views/ImportExport.vue
+++ b/src/views/ImportExport.vue
@@ -182,7 +182,7 @@ export default {
 
         if (errors.length) {
           this.$toasted.error(`${errors.length} items had errors.`)
-          saveAs(new Blob([yaml.safeDump(errors)], { type: 'text/plain;charset=utf-8' }), 'importErrors.yml')
+          saveAs(new Blob([yaml.dump(errors)], { type: 'text/plain;charset=utf-8' }), 'importErrors.yml')
         }
       }).catch((error) => {
         this.$toasted.error(`Error ${error}`)
@@ -227,7 +227,7 @@ export default {
       this.progressModalText = 'Generating YML extract...'
       // Get data
       DatabaseService().getAllItems().then((data) => {
-        saveAs(new Blob([yaml.safeDump(data.rows)], { type: 'text/plain;charset=utf-8' }), `${this.exportFileName}.yml`)
+        saveAs(new Blob([yaml.dump(data.rows)], { type: 'text/plain;charset=utf-8' }), `${this.exportFileName}.yml`)
         this.progressModalText = ''
       })
     },

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -47,7 +47,7 @@ export default {
               value: item.name,
               align: 'left',
               item: item, // So you can access all the parameters. Above are given in the data table support format.
-              sortable: false
+              sortable: true
             })
           })
         })


### PR DESCRIPTION
Current import/export appears to be broken.  It looks like yaml.safeDump has been removed for yaml.dump.  On the latest, I could export a JSON backup, but not a YAML one.  Also both imports appear to be broken.  I only get a "0 items imported".

HOWEVER, with this change, you at least get the error.yml file downloaded that explains what happened.  This was not working before.

I also thought it was a nice touch to allow the item list to be sortable.  This way if you want to sort by name, location, or whatever other header you can easily do so.